### PR TITLE
Ignore tokens with 'null' or 'undefined' info

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -142,9 +142,7 @@ function satisfiesTokenInfoSchema({
   const requiredKeys = ['chainId', 'address', 'name', 'symbol', 'decimals']
   if (includeOptionals) requiredKeys.push('logoURI')
 
-  return requiredKeys.every(
-    (key) => token?.[key as keyof TokenInfo] !== undefined
-  )
+  return requiredKeys.every((key) => token?.[key as keyof TokenInfo] != null)
 }
 
 async function setTokenInfo(


### PR DESCRIPTION
This function was only ignoring `undefined` values, not `null` and so there were some tokens (the Euler tokens) that were being added to the token list without a symbol or name: https://github.com/balancer/tokenlists/blob/main/generated/balancer.tokenlist.json#L4748

This ensures these tokens are not added. 