### PR TITLE
Update Gnosis RPC. Old one is failing

### DIFF
--- a/src/lib/fetchers/onchain.ts
+++ b/src/lib/fetchers/onchain.ts
@@ -6,9 +6,7 @@ import ERC20_ABI from '../abi/ERC20.abi.json'
 function getProvider(network: Network): InfuraProvider | JsonRpcProvider {
   if (!process.env.INFURA_KEY) throw new Error('Missing INFURA_KEY env var')
   if (network === Network.Gnosis) {
-    return new JsonRpcProvider(
-      `https://poa-xdai.gateway.pokt.network/v1/lb/${process.env.POKT_KEY}`
-    )
+    return new JsonRpcProvider(`https://rpc.gnosischain.com`)
   }
   if (network === Network.Zkevm) {
     return new JsonRpcProvider(


### PR DESCRIPTION
The current Gnosis RPC is often failing with:

```
JsonRpcProvider failed to startup; retry in 1s
JsonRpcProvider failed to startup; retry in 1s
JsonRpcProvider failed to startup; retry in 1s
JsonRpcProvider failed to startup; retry in 1s
```

See: https://github.com/balancer/tokenlists/actions/runs/5186207688/jobs/9347018673

Switching to a new one which is hopefully more stable. It works well for me with Metamask