### PR TITLE
Token allowlist automation improvements

### DIFF
--- a/.github/workflows/allowlist-webhook.yml
+++ b/.github/workflows/allowlist-webhook.yml
@@ -2,10 +2,10 @@ name: Allowlist Token Webhook
 
 on:
   repository_dispatch:
-    types: ['allowlist_pool']
+    types: ['allowlist_token']
 
 jobs:
-  allowlist-pool:
+  allowlist-token:
     uses: ./.github/workflows/allowlist.yml
     with:
       network: ${{ github.event.client_payload.network }}

--- a/src/config/arbitrum.ts
+++ b/src/config/arbitrum.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'arbitrum',
   coingecko: {
     platformId: 'arbitrum-one',
   },

--- a/src/config/avalanche.ts
+++ b/src/config/avalanche.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'avalanche',
   coingecko: {
     platformId: 'avalanche',
   },

--- a/src/config/ethereum.ts
+++ b/src/config/ethereum.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'ethereum',
   coingecko: {
     platformId: 'ethereum',
   },

--- a/src/config/gnosis.ts
+++ b/src/config/gnosis.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'gnosis',
   coingecko: {
     platformId: 'xdai',
   },

--- a/src/config/goerli.ts
+++ b/src/config/goerli.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'goerli',
   coingecko: {
     platformId: 'goerli',
   },

--- a/src/config/optimism.ts
+++ b/src/config/optimism.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'optimism',
   coingecko: {
     platformId: 'optimistic-ethereum',
   },

--- a/src/config/polygon.ts
+++ b/src/config/polygon.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'polygon',
   coingecko: {
     platformId: 'polygon-pos',
   },

--- a/src/config/zkevm.ts
+++ b/src/config/zkevm.ts
@@ -1,4 +1,5 @@
 export default {
+  name: 'zkevm',
   coingecko: {
     platformId: 'polygon-zkevm',
   },

--- a/src/lib/scripts/allowlist-token.ts
+++ b/src/lib/scripts/allowlist-token.ts
@@ -10,6 +10,8 @@
 
 import { cac } from 'cac'
 import { allowListToken } from './edit-tokenlist.js'
+import configs from '../../config'
+import { Config } from '../../types.js'
 
 const cli = cac()
 cli
@@ -44,15 +46,9 @@ function validateInput({
   network: string
   tokenAddress: string
 }) {
-  const networkNames = [
-    'arbitrum',
-    'gnosis-chain',
-    'goerli',
-    'mainnet',
-    'polygon',
-    'optimism',
-    'zkevm',
-  ]
+  const networkNames = Object.values(configs).map(
+    (config: Config) => config.name
+  )
   if (!networkNames.includes(network)) {
     throw Error(`Invalid network name: ${network}`)
   }

--- a/src/lib/scripts/edit-tokenlist.ts
+++ b/src/lib/scripts/edit-tokenlist.ts
@@ -18,7 +18,8 @@ export function allowListToken({
   const arrayContent = match[1].trim()
 
   if (arrayContent.includes(tokenAddress)) {
-    throw Error(`${tokenAddress} is already allowlisted`)
+    console.log(`${tokenAddress} is already allowlisted`)
+    return
   }
 
   let updatedArrayContent = `${arrayContent}\n  '${tokenAddress}',`

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export enum Network {
 }
 
 export interface Config {
+  name: string;
   coingecko: {
     platformId: string
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export enum Network {
 }
 
 export interface Config {
-  name: string;
+  name: string
   coingecko: {
     platformId: string
   }


### PR DESCRIPTION
- Hook was named wrong causing the automation to fail. 
- Don't error if already allowlisted, just return. 
- Use names from config
