### PR TITLE
Add custom RPC to config and for Base

### DIFF
--- a/src/config/avalanche.ts
+++ b/src/config/avalanche.ts
@@ -1,5 +1,6 @@
 export default {
   name: 'avalanche',
+  rpc: `https://avalanche-mainnet.infura.io/v3/${process.env.INFURA_KEY}`,
   coingecko: {
     platformId: 'avalanche',
   },

--- a/src/config/base.ts
+++ b/src/config/base.ts
@@ -1,5 +1,6 @@
 export default {
   name: 'base',
+  rpc: 'https://developer-access-mainnet.base.org',
   coingecko: {
     platformId: 'base',
   },

--- a/src/config/gnosis.ts
+++ b/src/config/gnosis.ts
@@ -1,5 +1,6 @@
 export default {
   name: 'gnosis',
+  rpc: 'https://rpc.gnosischain.com',
   coingecko: {
     platformId: 'xdai',
   },

--- a/src/config/zkevm.ts
+++ b/src/config/zkevm.ts
@@ -1,5 +1,7 @@
 export default {
   name: 'zkevm',
+  rpc:
+    `https://polygonzkevm-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_KEY}`,
   coingecko: {
     platformId: 'polygon-zkevm',
   },

--- a/src/config/zkevm.ts
+++ b/src/config/zkevm.ts
@@ -1,7 +1,7 @@
 export default {
   name: 'zkevm',
   rpc:
-    `https://polygonzkevm-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_KEY}`,
+    'https://polygonzkevm-mainnet.g.alchemy.com/v2/' + process.env.ALCHEMY_KEY,
   coingecko: {
     platformId: 'polygon-zkevm',
   },

--- a/src/lib/fetchers/onchain.ts
+++ b/src/lib/fetchers/onchain.ts
@@ -1,22 +1,14 @@
 import { getAddress, InfuraProvider, JsonRpcProvider } from 'ethers'
 import { Network, PartialTokenInfoMap } from '../../types'
+import config from '../../config'
 import { Multicaller } from '../multicaller'
 import ERC20_ABI from '../abi/ERC20.abi.json'
 
 function getProvider(network: Network): InfuraProvider | JsonRpcProvider {
   if (!process.env.INFURA_KEY) throw new Error('Missing INFURA_KEY env var')
-  if (network === Network.Gnosis) {
-    return new JsonRpcProvider(`https://rpc.gnosischain.com`)
-  }
-  if (network === Network.Zkevm) {
-    return new JsonRpcProvider(
-      `https://polygonzkevm-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_KEY}`
-    )
-  }
-  if (network === Network.Avalanche) {
-    return new JsonRpcProvider(
-      `https://avalanche-mainnet.infura.io/v3/${process.env.INFURA_KEY}`
-    )
+  const networkConfig = config[network]
+  if (networkConfig.rpc) {
+    return new JsonRpcProvider(networkConfig.rpc)
   }
   return new InfuraProvider(Number(network), process.env.INFURA_KEY)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export enum Network {
 
 export interface Config {
   name: string
+  rpc?: string
   coingecko: {
     platformId: string
   }


### PR DESCRIPTION
Build was failing because there is no Base JsonRpc config in Ethers. To ensure we don't forget to add custom RPC's in the future and make this cleaner I added it to the config and it is used instead of the InfuraProvider when it is set. 