### PR TITLE
Add PLATA (PLT) Token - ChainID 137 - balancer.tokenlist.json

### DIFF
--- a/generated/balancer.tokenlist.json
+++ b/generated/balancer.tokenlist.json
@@ -8536,6 +8536,15 @@
             "decimals": 18
         },
         {
+            
+            "chainId": 137,
+            "address": "0xc298812164bd558268f51cc6e3b8b5daaf0b6341",
+            "name": "PLATA",
+            "symbol": "PLT",
+            "decimals": 18,
+            "logoURI": "https://plata.ie/images/platatoken200px.png"
+        },
+        {
             "chainId": 1101,
             "address": "0x120eF59b80774F02211563834d8E3b72cb1649d6",
             "name": "Balancer",

--- a/generated/balancer.tokenlist.json
+++ b/generated/balancer.tokenlist.json
@@ -8541,7 +8541,7 @@
             "address": "0xc298812164bd558268f51cc6e3b8b5daaf0b6341",
             "name": "PLATA",
             "symbol": "PLT",
-            "decimals": 18,
+            "decimals": 4,
             "logoURI": "https://plata.ie/images/platatoken200px.png"
         },
         {


### PR DESCRIPTION
This Pull Request adds the smart contract for the PLATA (PLT) token on the network with ChainID 137. Here are the details of the modifications:

chainId: 137
address: 0xc298812164bd558268f51cc6e3b8b5daaf0b6341
name: PLATA
symbol: PLT
decimals: 4

logoURI: https://plata.ie/images/platatoken200px.png
This addition will enable the PLATA token to be recognized and utilized in applications and services that support the network with ChainID 137. Please review and approve these changes if you are in agreement.