### PR TITLE
overwrite matic

### DIFF
--- a/src/tokenlists/balancer/overwrites.ts
+++ b/src/tokenlists/balancer/overwrites.ts
@@ -265,6 +265,10 @@ export const overwrites: OverwritesForList = {
       symbol: 'wPOL',
       name: 'Wrapped Polygon Ecosystem Token',
     },
+    '0x0000000000000000000000000000000000001010': {
+      symbol: 'POL',
+      name: 'Polygon Ecosystem Token',
+    },
   },
   [Network.Arbitrum]: {
     '0xfc675adfdd721064ba923d07a8a238a9e52d8ace': {


### PR DESCRIPTION
overwrite matic so it's use is consistent everywhere in the zen ui

![image](https://github.com/user-attachments/assets/fde507a6-35f0-4ce4-ae64-eac32cbd6b74)
