### PR TITLE
Reset version in situatiuons where no changes exist

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -127,6 +127,7 @@ function buildTokenList(
 
   if (existingTokenList && isEqualTokenlists(newTokenList, existingTokenList)) {
     newTokenList.timestamp = existingTokenList.timestamp
+    newTokenList.metadata.version.patch = existingTokenList.version.
   }
 
   return newTokenList

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -127,7 +127,7 @@ function buildTokenList(
 
   if (existingTokenList && isEqualTokenlists(newTokenList, existingTokenList)) {
     newTokenList.timestamp = existingTokenList.timestamp
-    newTokenList.metadata.version.patch = existingTokenList.version.
+    newTokenList.version.patch = existingTokenList.version.patch
   }
 
   return newTokenList

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,8 +29,8 @@ export function isEqualTokenlists(
   oldTokenlist: TokenList
 ): boolean {
   return isEqual(
-    omit(oldTokenlist, 'timestamp'),
-    omit(newTokenlist, 'timestamp')
+    omit(oldTokenlist, ['timestamp', 'version.patch']),
+    omit(newTokenlist, ['timestamp', 'version.patch'])
   )
 }
 


### PR DESCRIPTION
 in order to prevent new PR.  Same as was done with timestamp.
 
#1672 as an example of an unneeded PR. 