### PR TITLE
Fix Typo in `zkevm.ts`

### DIFF
--- a/src/config/zkevm.ts
+++ b/src/config/zkevm.ts
@@ -4,7 +4,7 @@ export default {
   coingecko: {
     platformId: 'polygon-zkevm',
   },
-  trustWalletNetwork: 'polygonzkevm', // doesnt have a tokenlist on https://github.com/trustwallet/assets/tree/master/blockchains/polygonzkevm
+  trustWalletNetwork: 'polygonzkevm', // doesn't have a tokenlist on https://github.com/trustwallet/assets/tree/master/blockchains/polygonzkevm
   addresses: {
     multicaller: '0xca11bde05977b3631167028862be2a173976ca11',
   },


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `zkevm.ts`**

## Description  
This pull request corrects a typo in the `zkevm.ts` file. The word "doesnt" has been corrected to "doesn't" to ensure proper grammar and readability in the code comments.

### Changes Made:
- **File Modified:** `zkevm.ts`
- **Summary of Changes:**  
  - Corrected the typo from "doesnt" to "doesn't" in the comment on line 5.

## Checklist  
- [x] Fixed the typo in the file.
- [x] Verified that the code comment is clear and grammatically correct.

## Additional Notes  
This small change helps improve the clarity and professionalism of the code documentation.

---

**Allow edits by maintainers:** [x]
